### PR TITLE
Support for embedded-hal v1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,4 +19,6 @@ jobs:
     - name: Run tests
       run: cd cd74hc4067 && cargo test && cd -
     - name: Run build
-      run: rustup target add thumbv6m-none-eabi && cargo build --verbose --target thumbv6m-none-eabi
+      run: cd cd74hc4067 && rustup target add thumbv6m-none-eabi && cargo build --verbose --target thumbv6m-none-eabi
+    - name: Build Example
+      run: cd stm32f0-example && rustup target add thumbv6m-none-eabi && cargo build --verbose --target thumbv6m-none-eabi

--- a/cd74hc4067/Cargo.toml
+++ b/cd74hc4067/Cargo.toml
@@ -26,7 +26,17 @@ edition = "2018"
 version = "0.3.0"
 
 [dependencies]
-embedded-hal = "0.2.4"
+embedded-hal_0_2 = { package = "embedded-hal", version = "0.2.7", optional = true }
+embedded-hal = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
-embedded-hal-mock = "0.7.2"
+embedded-hal-mock = "0.11.1"
+
+[features]
+default = ["eh1"]
+
+# Support for embedded-hal v0.2 traits
+eh0 = ["embedded-hal_0_2"]
+
+# Support for embedded-hal v1.x traits
+eh1 = ["embedded-hal"]

--- a/cd74hc4067/src/lib.rs
+++ b/cd74hc4067/src/lib.rs
@@ -29,9 +29,11 @@ pub struct EnabledState;
 #[cfg_attr(test, derive(Debug))]
 pub struct DisabledState;
 
-use embedded_hal as hal;
+#[cfg(feature = "eh0")]
+use embedded_hal_0_2::digital::v2::OutputPin;
 
-use hal::digital::v2::OutputPin;
+#[cfg(not(feature = "eh0"))]
+use embedded_hal::digital::OutputPin;
 
 /// A structure representing the 4 input pins and pin_enable pin
 #[cfg_attr(test, derive(Debug))]
@@ -175,7 +177,13 @@ where
 mod tests {
     use super::*;
 
-    use embedded_hal_mock::pin::{
+    #[cfg(feature = "eh0")]
+    use embedded_hal_mock::eh0::digital::{
+        Mock as PinMock, State as PinState, Transaction as PinTransaction,
+    };
+
+    #[cfg(not(feature = "eh0"))]
+    use embedded_hal_mock::eh1::digital::{
         Mock as PinMock, State as PinState, Transaction as PinTransaction,
     };
 

--- a/stm32f0-example/Cargo.toml
+++ b/stm32f0-example/Cargo.toml
@@ -19,7 +19,7 @@ embedded-hal = "0.2.4"
 rtt-target = { version = "0.2.2", features = ["cortex-m"], optional = true }
 panic-rtt-target = { version = "0.1.1", features = ["cortex-m"], optional = true }
 stm32f0xx-hal = { version = "0.17.1", features = ["rt", "stm32f072"] }
-cd74hc4067 = { path = "../cd74hc4067/" }
+cd74hc4067 = { path = "../cd74hc4067/", features = ["eh0"] }
 picorand = "0.1.1"
 debugless-unwrap = "0.0.4"
 


### PR DESCRIPTION
This PR adds support for embedded-hal v1.
However, we can still discuss the way of implementation. Not sure whether the implemented feature configuration is the best choice.